### PR TITLE
Rendering errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chemist",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An opinionated React framework",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Catch errors in rendering and pass them back to the express app. Previously this error was uncaught, resulting in a frustrating infinite load. Now it's left up to the express app to handle it with error handling middleware.
