### PR TITLE
Support multiple webpack configs in compile

### DIFF
--- a/src/bin/cli/commands/compile.js
+++ b/src/bin/cli/commands/compile.js
@@ -2,16 +2,23 @@ import webpack from 'webpack'
 import config from '../../../config'
 import * as Logger from '../helpers/logger'
 
+const logAssetSuccess = assets => Logger.success(`Succesfully compiled ${assets.main}`)
+
 export default function compile () {
   process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
   webpack(config('webpack'), function (err, stats) {
     if (err) throw err
 
-    const { errors, warnings, assetsByChunkName } = stats.toJson()
+    const { errors, warnings, children, assetsByChunkName } = stats.toJson()
+
     if (errors.length > 0) errors.map(webpackError => Logger.error(webpackError))
     if (warnings.length > 0) warnings.map(webpackWarning => Logger.warn(webpackWarning))
 
-    Logger.success(`Succesfully compiled ${assetsByChunkName.main}`)
+    if (Array.isArray(children)) {
+      children.forEach(child => logAssetSuccess(child.assetsByChunkName))
+    } else {
+      logAssetSuccess(assetsByChunkName)
+    }
   })
 }


### PR DESCRIPTION
Webpack stats vary if the webpack config is an array of hashes, rather than a single hash, so we need to update the way we display successful builds. Theme support in flourish is gonna require arrays.