### PR TITLE
Make asset dev server configurable in applications

### DIFF
--- a/src/bin/cli/commands/watch.js
+++ b/src/bin/cli/commands/watch.js
@@ -1,5 +1,3 @@
-import path from 'path'
-import fs from 'fs'
 import express from 'express'
 import webpack from 'webpack'
 import webpackDevMiddleware from 'webpack-dev-middleware'
@@ -7,37 +5,18 @@ import webpackHotMiddleware from 'webpack-hot-middleware'
 import config from '../../../config'
 import * as Logger from '../helpers/logger'
 
-const configPath = path.join(process.cwd(), './config')
-
-let appConfig = {}
-
-if (fs.existsSync(configPath)) {
-  appConfig = require(configPath)
-}
-
 export default function watch () {
   process.env.NODE_ENV = 'development'
   process.env.UV_THREADPOOL_SIZE = 100
+  const { app: appConfig } = config('index')
   const webpackConfig = config('webpack')
+  const serverConfig = config('webpack-dev-server')
 
   const compiler = webpack(webpackConfig)
-  const host = appConfig.host || 'localhost'
   const port = appConfig.webpackPort || 3001
   const app = express()
 
-  const serverOptions = {
-    contentBase: `http://${host}:${port}`,
-    quiet: true,
-    noInfo: true,
-    hot: true,
-    inline: true,
-    lazy: false,
-    publicPath: webpackConfig.output.publicPath,
-    headers: { 'Access-Control-Allow-Origin': '*' },
-    stats: { colors: true }
-  }
-
-  app.use(webpackDevMiddleware(compiler, serverOptions))
+  app.use(webpackDevMiddleware(compiler, serverConfig))
   app.use(webpackHotMiddleware(compiler))
   app.listen(port, function (err) {
     if (err) {

--- a/src/config/default/webpack-dev-server.js
+++ b/src/config/default/webpack-dev-server.js
@@ -1,0 +1,19 @@
+import config from '../'
+
+export default function () {
+  const appConfig = config('index')
+  const webpackConfig = config('webpack')
+  const { host, webpackPort } = appConfig
+
+  return {
+    contentBase: `http://${host}:${webpackPort}`,
+    quiet: true,
+    noInfo: true,
+    hot: true,
+    inline: true,
+    lazy: false,
+    publicPath: webpackConfig.output.publicPath,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    stats: { colors: true }
+  }
+}


### PR DESCRIPTION
This relies on the webpack publicPath config, which I still think is a sensible choice for most apps, so makes sense to leave here. Unfortunately won't make sense for flourish anymore, as that has multiple webpack configs.