### PR TITLE
Support WEBPACK_DEV_PORT env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chemist",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "An opinionated React framework",
   "main": "dist/index.js",
   "bin": {

--- a/src/bin/cli/commands/watch.js
+++ b/src/bin/cli/commands/watch.js
@@ -13,11 +13,12 @@ export default function watch () {
   const serverConfig = config('webpack-dev-server')
 
   const compiler = webpack(webpackConfig)
-  const port = appConfig.webpackPort || 3001
+  const port = process.env.WEBPACK_DEV_PORT || appConfig.webpackPort || 3001
   const app = express()
 
   app.use(webpackDevMiddleware(compiler, serverConfig))
   app.use(webpackHotMiddleware(compiler))
+
   app.listen(port, function (err) {
     if (err) {
       Logger.error(err)


### PR DESCRIPTION
This makes it easier for us to run multiple instances of the app with different asset watch servers in dev.